### PR TITLE
Added an option to select the hardware SPI module number. Fixed print…

### DIFF
--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -153,11 +153,12 @@
 #define PN532_GPIO_P34                      (4)
 #define PN532_GPIO_P35                      (5)
 
+class SPIClass;
 class Adafruit_PN532{
  public:
   Adafruit_PN532(uint8_t clk, uint8_t miso, uint8_t mosi, uint8_t ss);  // Software SPI
   Adafruit_PN532(uint8_t irq, uint8_t reset);  // Hardware I2C
-  Adafruit_PN532(uint8_t ss);  // Hardware SPI
+  Adafruit_PN532(uint8_t ss, SPIClass* _hardwareSPI = &SPI);  // Hardware SPI
   void begin(void);
   
   // Generic PN532 functions
@@ -196,14 +197,15 @@ class Adafruit_PN532{
   static void PrintHexChar(const byte * pbtData, const uint32_t numBytes);
 
  private:
-  uint8_t _ss, _clk, _mosi, _miso;
-  uint8_t _irq, _reset;
-  uint8_t _uid[7];       // ISO14443A uid
-  uint8_t _uidLen;       // uid len
-  uint8_t _key[6];       // Mifare Classic key
-  uint8_t _inListedTag;  // Tg number of inlisted tag.
-  bool    _usingSPI;     // True if using SPI, false if using I2C.
-  bool    _hardwareSPI;  // True is using hardware SPI, false if using software SPI.
+  uint8_t   _ss, _clk, _mosi, _miso;
+  uint8_t   _irq, _reset;
+  uint8_t   _uid[7];       // ISO14443A uid
+  uint8_t   _uidLen;       // uid len
+  uint8_t   _key[6];       // Mifare Classic key
+  uint8_t   _inListedTag;  // Tg number of inlisted tag.
+  bool      _usingSPI;     // True if using SPI, false if using I2C.
+  SPIClass* _hardwareSPI;  // Not NULL is using hardware SPI, NULL if using software SPI.
+
 
   // Low level communication functions that handle both SPI and I2C.
   void readdata(uint8_t* buff, uint8_t n);


### PR DESCRIPTION
…out of sent data (at least on STM32 platform). Fixed warning about incorrect initialization order in constructor initialization lists.

Signed-off-by: Alexandr Zarubkin <me21@yandex.ru>

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
